### PR TITLE
Add subscription mapping fix for plan_id and plan_name issues

### DIFF
--- a/backend/cmd/fix-subscription-mapping/main.go
+++ b/backend/cmd/fix-subscription-mapping/main.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+
+	"bome-backend/internal/config"
+	"bome-backend/internal/database"
+
+	_ "github.com/lib/pq"
+)
+
+func main() {
+	log.Println("🔧 Starting subscription mapping fix...")
+
+	// Load configuration
+	cfg := config.Load()
+	
+	// Connect to database
+	db, err := database.Connect(cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("❌ Failed to connect to database: %v", err)
+	}
+	defer db.Close()
+
+	log.Println("✅ Connected to database")
+
+	// Step 1: Create price mapping based on stripe_prices table and unit_amount
+	// Based on the stripe_prices data provided
+	priceMapping := map[int64]int{
+		997:   11, // EMonth price -> Monthly plan (plan_id 11)
+		999:   11, // premiummonthly price -> Monthly plan (plan_id 11)
+		8982:  12, // PPlan price (Legacy Semi-Annual) -> Annual plan (plan_id 12)
+		9564:  12, // YPremium price -> Annual plan (plan_id 12) 
+		7200:  12, // bestvaluepromo price -> Annual plan (plan_id 12)
+	}
+
+	log.Println("💰 Price to Plan ID mapping:")
+	for price, planID := range priceMapping {
+		log.Printf("  $%.2f (unit_amount: %d) -> Plan ID: %d", float64(price)/100, price, planID)
+	}
+
+	// Step 2: Update users.sub_id based on their active Stripe subscriptions
+	updateQuery := `
+		UPDATE users 
+		SET sub_id = $1, updated_at = NOW()
+		WHERE id IN (
+			SELECT u.id
+			FROM users u
+			INNER JOIN stripe_customers sc ON u.stripe_customer_id = sc.stripe_id
+			INNER JOIN stripe_subscriptions ss ON sc.id = ss.customer_id
+			WHERE ss.status IN ('active', 'trialing')
+			AND ss.unit_amount = $2
+			AND u.sub_id IS NULL
+		)
+	`
+
+	totalUpdated := 0
+	
+	for unitAmount, planID := range priceMapping {
+		result, err := db.Exec(updateQuery, planID, unitAmount)
+		if err != nil {
+			log.Printf("❌ Error updating users for unit_amount %d: %v", unitAmount, err)
+			continue
+		}
+
+		rowsAffected, _ := result.RowsAffected()
+		log.Printf("✅ Updated %d users with unit_amount %d to plan_id %d", rowsAffected, unitAmount, planID)
+		totalUpdated += int(rowsAffected)
+	}
+
+	log.Printf("🎉 Total users updated: %d", totalUpdated)
+
+	// Step 3: Update product_name in stripe_subscriptions based on unit_amount
+	productNameMapping := map[int64]string{
+		997:   "Basic Monthly",
+		999:   "Premium Monthly",
+		8982:  "Premium Semi-Annual",
+		9564:  "Premium Annual", 
+		7200:  "Best Value Annual",
+	}
+
+	log.Println("📝 Updating product names in stripe_subscriptions...")
+
+	updateProductNameQuery := `
+		UPDATE stripe_subscriptions 
+		SET product_name = $1, updated_at = NOW()
+		WHERE unit_amount = $2 
+		AND (product_name IS NULL OR product_name = '')
+	`
+
+	for unitAmount, productName := range productNameMapping {
+		result, err := db.Exec(updateProductNameQuery, productName, unitAmount)
+		if err != nil {
+			log.Printf("❌ Error updating product_name for unit_amount %d: %v", unitAmount, err)
+			continue
+		}
+
+		rowsAffected, _ := result.RowsAffected()
+		log.Printf("✅ Updated %d subscriptions with unit_amount %d to product_name '%s'", rowsAffected, unitAmount, productName)
+	}
+
+	// Step 4: Verify the fix
+	log.Println("🔍 Verifying the fix...")
+	
+	verifyQuery := `
+		SELECT 
+			u.id, u.email, u.sub_id, sp.name as plan_name, ss.unit_amount, ss.product_name
+		FROM users u
+		LEFT JOIN subscription_plans sp ON u.sub_id = sp.id
+		LEFT JOIN stripe_customers sc ON u.stripe_customer_id = sc.stripe_id
+		LEFT JOIN stripe_subscriptions ss ON sc.id = ss.customer_id AND ss.status IN ('active', 'trialing')
+		WHERE u.email = 'mycommonsensefinancial@yahoo.com'
+	`
+
+	var userID int
+	var email string
+	var subID sql.NullInt32
+	var planName sql.NullString
+	var unitAmount sql.NullInt64
+	var productName sql.NullString
+
+	err = db.QueryRow(verifyQuery).Scan(&userID, &email, &subID, &planName, &unitAmount, &productName)
+	if err != nil {
+		log.Printf("❌ Error verifying fix: %v", err)
+	} else {
+		log.Printf("🔍 Verification for %s (ID: %d):", email, userID)
+		log.Printf("  sub_id: %v", subID)
+		log.Printf("  plan_name: %v", planName)
+		log.Printf("  unit_amount: %v", unitAmount)
+		log.Printf("  product_name: %v", productName)
+	}
+
+	log.Println("🎉 Subscription mapping fix completed!")
+}

--- a/backend/scripts/fix-subscription-mapping.sql
+++ b/backend/scripts/fix-subscription-mapping.sql
@@ -1,0 +1,143 @@
+-- Fix Subscription Mapping: Connect Stripe subscriptions to local subscription plans
+-- This fixes the issue where plan_id = 0 and plan_name = "" in production
+-- Uses stripe_prices table for accurate mapping
+
+-- Step 1: Update users.sub_id based on their active Stripe subscription
+-- Map using stripe_prices table to get accurate plan mapping
+
+-- Monthly Plan: EMonth price (997 cents) -> plan_id 11
+UPDATE users 
+SET sub_id = 11, updated_at = NOW()
+WHERE id IN (
+    SELECT DISTINCT u.id
+    FROM users u
+    INNER JOIN stripe_customers sc ON u.stripe_customer_id = sc.stripe_id
+    INNER JOIN stripe_subscriptions ss ON sc.id = ss.customer_id
+    WHERE ss.status IN ('active', 'trialing')
+    AND ss.unit_amount = 997
+    AND u.sub_id IS NULL
+);
+
+-- Annual Plan: YPremium price (9564 cents) -> plan_id 12  
+UPDATE users 
+SET sub_id = 12, updated_at = NOW()
+WHERE id IN (
+    SELECT DISTINCT u.id
+    FROM users u
+    INNER JOIN stripe_customers sc ON u.stripe_customer_id = sc.stripe_id
+    INNER JOIN stripe_subscriptions ss ON sc.id = ss.customer_id
+    WHERE ss.status IN ('active', 'trialing')
+    AND ss.unit_amount = 9564
+    AND u.sub_id IS NULL
+);
+
+-- Legacy Premium Semi-Annual: PPlan price (8982 cents) -> plan_id 12 (map to Annual)
+UPDATE users 
+SET sub_id = 12, updated_at = NOW()
+WHERE id IN (
+    SELECT DISTINCT u.id
+    FROM users u
+    INNER JOIN stripe_customers sc ON u.stripe_customer_id = sc.stripe_id
+    INNER JOIN stripe_subscriptions ss ON sc.id = ss.customer_id
+    WHERE ss.status IN ('active', 'trialing')
+    AND ss.unit_amount = 8982
+    AND u.sub_id IS NULL
+);
+
+-- Handle other common price points
+-- Premium Monthly: premiummonthly price (999 cents) -> plan_id 11
+UPDATE users 
+SET sub_id = 11, updated_at = NOW()
+WHERE id IN (
+    SELECT DISTINCT u.id
+    FROM users u
+    INNER JOIN stripe_customers sc ON u.stripe_customer_id = sc.stripe_id
+    INNER JOIN stripe_subscriptions ss ON sc.id = ss.customer_id
+    WHERE ss.status IN ('active', 'trialing')
+    AND ss.unit_amount = 999
+    AND u.sub_id IS NULL
+);
+
+-- Best Value Promo: bestvaluepromo price (7200 cents) -> plan_id 12
+UPDATE users 
+SET sub_id = 12, updated_at = NOW()
+WHERE id IN (
+    SELECT DISTINCT u.id
+    FROM users u
+    INNER JOIN stripe_customers sc ON u.stripe_customer_id = sc.stripe_id
+    INNER JOIN stripe_subscriptions ss ON sc.id = ss.customer_id
+    WHERE ss.status IN ('active', 'trialing')
+    AND ss.unit_amount = 7200
+    AND u.sub_id IS NULL
+);
+
+-- Step 2: Update product_name in stripe_subscriptions for better display
+UPDATE stripe_subscriptions 
+SET product_name = 'Basic Monthly', updated_at = NOW()
+WHERE unit_amount IN (997, 999)
+AND (product_name IS NULL OR product_name = '');
+
+UPDATE stripe_subscriptions 
+SET product_name = 'Premium Annual', updated_at = NOW()
+WHERE unit_amount = 9564 
+AND (product_name IS NULL OR product_name = '');
+
+UPDATE stripe_subscriptions 
+SET product_name = 'Premium Semi-Annual', updated_at = NOW()
+WHERE unit_amount = 8982 
+AND (product_name IS NULL OR product_name = '');
+
+UPDATE stripe_subscriptions 
+SET product_name = 'Best Value Annual', updated_at = NOW()
+WHERE unit_amount = 7200 
+AND (product_name IS NULL OR product_name = '');
+
+-- Step 3: Verify the fix for our test user
+SELECT 
+    u.id, 
+    u.email, 
+    u.sub_id, 
+    sp.name as plan_name, 
+    sp.price as plan_price,
+    ss.unit_amount, 
+    ss.product_name,
+    ss.status
+FROM users u
+LEFT JOIN subscription_plans sp ON u.sub_id = sp.id
+LEFT JOIN stripe_customers sc ON u.stripe_customer_id = sc.stripe_id
+LEFT JOIN stripe_subscriptions ss ON sc.id = ss.customer_id AND ss.status IN ('active', 'trialing')
+WHERE u.email = 'mycommonsensefinancial@yahoo.com';
+
+-- Step 4: Check how many users were affected by unit_amount
+SELECT 
+    ss.unit_amount,
+    COUNT(*) as subscriber_count,
+    CASE 
+        WHEN ss.unit_amount = 997 THEN 'Basic Monthly ($9.97)'
+        WHEN ss.unit_amount = 999 THEN 'Premium Monthly ($9.99)'
+        WHEN ss.unit_amount = 8982 THEN 'Premium Semi-Annual ($89.82)'
+        WHEN ss.unit_amount = 9564 THEN 'Premium Annual ($95.64)'
+        WHEN ss.unit_amount = 7200 THEN 'Best Value Annual ($72.00)'
+        ELSE 'Other'
+    END as plan_description
+FROM users u
+INNER JOIN stripe_customers sc ON u.stripe_customer_id = sc.stripe_id
+INNER JOIN stripe_subscriptions ss ON sc.id = ss.customer_id
+WHERE ss.status IN ('active', 'trialing')
+GROUP BY ss.unit_amount
+ORDER BY ss.unit_amount;
+
+-- Step 5: Summary of fixes
+SELECT 
+    'Users with sub_id now set' as description,
+    COUNT(*) as count
+FROM users 
+WHERE sub_id IS NOT NULL;
+
+SELECT 
+    'Active subscriptions with product_name' as description,
+    COUNT(*) as count
+FROM stripe_subscriptions 
+WHERE status IN ('active', 'trialing') 
+AND product_name IS NOT NULL 
+AND product_name != '';


### PR DESCRIPTION
- Create SQL script to map Stripe subscriptions to local subscription plans
- Map unit_amount from stripe_subscriptions to subscription_plans.id
- Handle all price points: 997, 999, 8982, 9564, 7200 cents
- Update users.sub_id based on active Stripe subscriptions
- Populate missing product_name in stripe_subscriptions
- Fixes production issue where plan_id=0 and plan_name=''

BOME BABY!